### PR TITLE
fixed "Edit in codepen" for examples in documentation.

### DIFF
--- a/components/helpers/Example.vue
+++ b/components/helpers/Example.vue
@@ -218,7 +218,7 @@
         })
       },
       sendToCodepen () {
-        this.$refs.codepen.submit()
+        this.getMarkup().then(() => this.$refs.codepen.submit())
       }
     }
   }


### PR DESCRIPTION
You are loading the example content when they open the "View source" panel, however you aren't loading it when they click "Edit in codepen", thus sending them to a blank codepen because there is no data in the codepen component.

I'm simply using your getMarkup() promise when they click the button so the data is there and ready.