### PR TITLE
Simplified each selection controls example. Documentation provided for text-field properties.

### DIFF
--- a/examples/selection-controls/checkboxesArray.vue
+++ b/examples/selection-controls/checkboxesArray.vue
@@ -1,27 +1,8 @@
 <template>
   <v-container fluid>
-    <v-layout row wrap>
-      <v-flex xs12 md6>
-        <v-subheader>Light</v-subheader>
-        <v-card flat>
-          <v-card-text>
-            <p>{{ ex5 }}</p>
-            <v-checkbox label="John" v-model="ex5" value="John"></v-checkbox>
-            <v-checkbox label="Jacob" v-model="ex5" value="Jacob"></v-checkbox>
-          </v-card-text>
-        </v-card>
-      </v-flex>
-      <v-flex xs12 md6>
-        <v-subheader>Dark</v-subheader>
-        <v-card color="grey darken-3" flat>
-          <v-card-text>
-            <p class="white--text">{{ ex6 }}</p>
-            <v-checkbox label="John" v-model="ex6" value="John" dark></v-checkbox>
-            <v-checkbox label="Jacob" v-model="ex6" value="Jacob" dark></v-checkbox>
-          </v-card-text>
-        </v-card>
-      </v-flex>
-    </v-layout>
+    <p>{{ ex6 }}</p>
+    <v-checkbox label="John" v-model="ex6" value="John"></v-checkbox>
+    <v-checkbox label="Jacob" v-model="ex6" value="Jacob"></v-checkbox>
   </v-container>
 </template>
 

--- a/examples/selection-controls/checkboxesBoolean.vue
+++ b/examples/selection-controls/checkboxesBoolean.vue
@@ -1,25 +1,7 @@
 <template>
   <v-container fluid>
-    <v-layout row wrap>
-      <v-flex xs12 md6>
-        <v-subheader>Light</v-subheader>
-        <v-card flat>
-          <v-card-text>
-            <v-checkbox v-bind:label="`Checkbox 1: ${ex1.toString()}`" v-model="ex1" light></v-checkbox>
-            <v-checkbox v-bind:label="`Checkbox 2: ${ex2.toString()}`" v-model="ex2" light></v-checkbox>
-          </v-card-text>
-        </v-card>
-      </v-flex>
-      <v-flex xs12 md6>
-        <v-subheader>Dark</v-subheader>
-        <v-card color="grey darken-3" flat>
-          <v-card-text>
-            <v-checkbox v-bind:label="`Checkbox 2: ${ex3.toString()}`" v-model="ex3" dark></v-checkbox>
-            <v-checkbox v-bind:label="`Checkbox 2: ${ex4.toString()}`" v-model="ex4" dark></v-checkbox>
-          </v-card-text>
-        </v-card>
-      </v-flex>
-    </v-layout>
+    <v-checkbox v-bind:label="`Checkbox 1: ${ex1.toString()}`" v-model="ex1" light></v-checkbox>
+    <v-checkbox v-bind:label="`Checkbox 2: ${ex2.toString()}`" v-model="ex2" light></v-checkbox>
   </v-container>
 </template>
 

--- a/examples/selection-controls/checkboxesStates.vue
+++ b/examples/selection-controls/checkboxesStates.vue
@@ -1,80 +1,32 @@
 <template>
   <v-container fluid>
-    <v-layout row wrap>
-      <v-flex xs12 md6>
-        <v-subheader>Light</v-subheader>
-        <v-card flat>
-          <v-card-text>
-            <v-container fluid>
-              <v-layout row wrap class="dark--text">
-                <v-flex xs4>on</v-flex>
-                <v-flex xs4>off</v-flex>
-                <v-flex xs4>indeterminate</v-flex>
-              </v-layout>
-              <v-layout row wrap>
-                <v-flex xs4>
-                  <v-checkbox input-value="true" value></v-checkbox>
-                </v-flex>
-                <v-flex xs4>
-                  <v-checkbox value></v-checkbox>
-                </v-flex>
-                <v-flex xs4>
-                  <v-checkbox value indeterminate></v-checkbox>
-                </v-flex>
-              </v-layout>
-              <v-layout row wrap class="dark--text">
-                <v-flex xs4>on disabled</v-flex>
-                <v-flex xs4>off disabled</v-flex>
-              </v-layout>
-              <v-layout row wrap>
-                <v-flex xs4>
-                  <v-checkbox input-value="true" value disabled></v-checkbox>
-                </v-flex>
-                <v-flex xs4>
-                  <v-checkbox value disabled></v-checkbox>
-                </v-flex>
-              </v-layout>
-            </v-container>
-          </v-card-text>
-        </v-card>
-      </v-flex>
-      <v-flex xs12 md6>
-        <v-subheader>Dark</v-subheader>
-        <v-card color="grey darken-3" flat dark>
-          <v-card-text>
-            <v-container fluid>
-              <v-layout row wrap class="light--text">
-                <v-flex xs4>on</v-flex>
-                <v-flex xs4>off</v-flex>
-                <v-flex xs4>indeterminate</v-flex>
-              </v-layout>
-              <v-layout row wrap>
-                <v-flex xs4>
-                  <v-checkbox input-value="true" value></v-checkbox>
-                </v-flex>
-                <v-flex xs4>
-                  <v-checkbox value></v-checkbox>
-                </v-flex>
-                <v-flex xs4>
-                  <v-checkbox value indeterminate></v-checkbox>
-                </v-flex>
-              </v-layout>
-              <v-layout row wrap class="light--text">
-                <v-flex xs4>on disabled</v-flex>
-                <v-flex xs4>off disabled</v-flex>
-              </v-layout>
-              <v-layout row wrap>
-                <v-flex xs4>
-                  <v-checkbox input-value="true" value disabled></v-checkbox>
-                </v-flex>
-                <v-flex xs4>
-                  <v-checkbox value disabled></v-checkbox>
-                </v-flex>
-              </v-layout>
-            </v-container>
-          </v-card-text>
-        </v-card>
-      </v-flex>
-    </v-layout>
+      <v-layout row wrap class="light--text">
+        <v-flex xs4>on</v-flex>
+        <v-flex xs4>off</v-flex>
+        <v-flex xs4>indeterminate</v-flex>
+      </v-layout>
+      <v-layout row wrap>
+        <v-flex xs4>
+          <v-checkbox input-value="true" value></v-checkbox>
+        </v-flex>
+        <v-flex xs4>
+          <v-checkbox value></v-checkbox>
+        </v-flex>
+        <v-flex xs4>
+          <v-checkbox value indeterminate></v-checkbox>
+        </v-flex>
+      </v-layout>
+      <v-layout row wrap class="light--text">
+        <v-flex xs4>on disabled</v-flex>
+        <v-flex xs4>off disabled</v-flex>
+      </v-layout>
+      <v-layout row wrap>
+        <v-flex xs4>
+          <v-checkbox input-value="true" value disabled></v-checkbox>
+        </v-flex>
+        <v-flex xs4>
+          <v-checkbox value disabled></v-checkbox>
+        </v-flex>
+      </v-layout>
   </v-container>
 </template>

--- a/examples/selection-controls/example.vue
+++ b/examples/selection-controls/example.vue
@@ -1,44 +1,21 @@
 <template>
   <v-container fluid px-0>
-    <v-layout row wrap>
-      <v-flex
-        xs12
-        md6
-        v-for="color in ['Light', 'Dark']"
-        :key="color"
-      >
-        <v-subheader v-text="color"></v-subheader>
-        <v-card flat tile :color="color === 'Dark' ? 'grey darken-3' : ''">
-          <v-card-text>
-            <v-checkbox
-              v-bind:label="`Checkbox 1: ${ex1.toString()}`"
-              v-model="ex1"
-              :color="color === 'Dark' ? 'blue accent-1' : ''"
-              :light="color === 'Light'"
-              :dark="color === 'Dark'"
-            ></v-checkbox>
-            <v-radio-group v-model="ex2">
-              <v-radio
-                v-for="n in 3"
-                :key="n"
-                v-bind:label="`Radio ${n}`"
-                :color="color === 'Dark' ? 'blue accent-1' : ''"
-                :value="n"
-                :light="color === 'Light'"
-                :dark="color === 'Dark'"
-              ></v-radio>
-            </v-radio-group>
-            <v-switch
-              v-bind:label="`Switch 1: ${ex1.toString()}`"
-              v-model="ex3"
-              :color="color === 'Dark' ? 'blue accent-1' : ''"
-              :light="color === 'Light'"
-              :dark="color === 'Dark'"
-            ></v-switch>
-          </v-card-text>
-        </v-card>
-      </v-flex>
-    </v-layout>
+    <v-checkbox
+      v-bind:label="`Checkbox 1: ${ex1.toString()}`"
+      v-model="ex1"
+    ></v-checkbox>
+    <v-radio-group v-model="ex2">
+      <v-radio
+        v-for="n in 3"
+        :key="n"
+        v-bind:label="`Radio ${n}`"
+        :value="n"
+      ></v-radio>
+    </v-radio-group>
+    <v-switch
+      v-bind:label="`Switch 1: ${ex1.toString()}`"
+      v-model="ex3"
+    ></v-switch>
   </v-container>
 </template>
 

--- a/examples/selection-controls/radiosDefault.vue
+++ b/examples/selection-controls/radiosDefault.vue
@@ -1,31 +1,10 @@
 <template>
   <v-container fluid>
-    <v-layout row wrap>
-      <v-flex xs12 md6>
-        <v-subheader>Light</v-subheader>
-        <v-card flat>
-          <v-card-text>
-            <p>{{ ex8 || 'null' }}</p>
-            <v-radio-group v-model="ex8" :mandatory="false">
-              <v-radio label="Radio 1" value="radio-1"></v-radio>
-              <v-radio label="Radio 2" value="radio-2"></v-radio>
-            </v-radio-group>
-          </v-card-text>
-        </v-card>
-      </v-flex>
-      <v-flex xs12 md6>
-        <v-subheader>Dark</v-subheader>
-        <v-card color="grey darken-3" flat>
-          <v-card-text>
-            <p class="white--text">{{ ex9 || 'null' }}</p>
-            <v-radio-group v-model="ex9" :mandatory="false">
-              <v-radio label="Radio 3" value="radio-3" dark></v-radio>
-              <v-radio label="Radio 4" value="radio-4" dark></v-radio>
-            </v-radio-group>
-          </v-card-text>
-        </v-card>
-      </v-flex>
-    </v-layout>
+    <p>{{ ex8 || 'null' }}</p>
+    <v-radio-group v-model="ex8" :mandatory="false">
+      <v-radio label="Radio 1" value="radio-1"></v-radio>
+      <v-radio label="Radio 2" value="radio-2"></v-radio>
+    </v-radio-group>
   </v-container>
 </template>
 
@@ -33,8 +12,7 @@
   export default {
     data () {
       return {
-        ex8: 'radio-1',
-        ex9: 'radio-3',
+        ex8: 'radio-1'
       }
     }
   }

--- a/examples/selection-controls/radiosDirection.vue
+++ b/examples/selection-controls/radiosDirection.vue
@@ -1,29 +1,14 @@
 <template>
   <v-container fluid>
-    <v-layout row wrap>
-      <v-flex xs12 md6>
-        <v-subheader>Column</v-subheader>
-        <v-card flat>
-          <v-card-text>
-            <v-radio-group v-model="column" column>
-              <v-radio label="Option 1" value="radio-1" ></v-radio>
-              <v-radio label="Option 2" value="radio-2"></v-radio>
-            </v-radio-group>
-          </v-card-text>
-        </v-card>
-      </v-flex>
-      <v-flex xs12 md6>
-        <v-subheader>Row</v-subheader>
-        <v-card flat>
-          <v-card-text>
-            <v-radio-group v-model="row" row>
-              <v-radio label="Option 1" value="radio-1" ></v-radio>
-              <v-radio label="Option 2" value="radio-2"></v-radio>
-            </v-radio-group>
-          </v-card-text>
-        </v-card>
-      </v-flex>
-    </v-layout>
+    <v-radio-group v-model="column" column>
+      <v-radio label="Option 1" value="radio-1" ></v-radio>
+      <v-radio label="Option 2" value="radio-2"></v-radio>
+    </v-radio-group>
+    <hr/>
+    <v-radio-group v-model="row" row>
+      <v-radio label="Option 1" value="radio-1" ></v-radio>
+      <v-radio label="Option 2" value="radio-2"></v-radio>
+    </v-radio-group>
   </v-container>
 </template>
 

--- a/examples/selection-controls/switchesArray.vue
+++ b/examples/selection-controls/switchesArray.vue
@@ -1,27 +1,8 @@
 <template>
   <v-container fluid>
-    <v-layout row wrap>
-      <v-flex xs12 md6>
-        <v-subheader>Light</v-subheader>
-        <v-card flat>
-          <v-card-text>
-            <p>{{ ex15 }}</p>
-            <v-switch label="John" v-model="ex15" value="John"></v-switch>
-            <v-switch label="Jacob" v-model="ex15" value="Jacob"></v-switch>
-          </v-card-text>
-        </v-card>
-      </v-flex>
-      <v-flex xs12 md6>
-        <v-subheader>Dark</v-subheader>
-        <v-card color="grey darken-3" flat>
-          <v-card-text>
-            <p class="white--text">{{ ex16 }}</p>
-            <v-switch label="John" v-model="ex16" value="John" dark></v-switch>
-            <v-switch label="Jacob" v-model="ex16" value="Jacob" dark></v-switch>
-          </v-card-text>
-        </v-card>
-      </v-flex>
-    </v-layout>
+    <p>{{ ex15 }}</p>
+    <v-switch label="John" v-model="ex15" value="John"></v-switch>
+    <v-switch label="Jacob" v-model="ex15" value="Jacob"></v-switch>
   </v-container>
 </template>
 
@@ -29,8 +10,7 @@
   export default {
     data () {
       return {
-        ex15: ['John'],
-        ex16: ['John'],
+        ex15: ['John']
       }
     }
   }

--- a/examples/selection-controls/switchesBoolean.vue
+++ b/examples/selection-controls/switchesBoolean.vue
@@ -1,25 +1,7 @@
 <template>
   <v-container fluid>
-    <v-layout row wrap>
-      <v-flex xs12 md6>
-        <v-subheader>Light</v-subheader>
-        <v-card flat>
-          <v-card-text>
-            <v-switch v-bind:label="`Switch 1: ${ex11.toString()}`" v-model="ex11"></v-switch>
-            <v-switch v-bind:label="`Switch 2: ${ex12.toString()}`" v-model="ex12"></v-switch>
-          </v-card-text>
-        </v-card>
-      </v-flex>
-      <v-flex xs12 md6>
-        <v-subheader>Dark</v-subheader>
-        <v-card color="grey darken-3" flat>
-          <v-card-text>
-            <v-switch v-bind:label="`Switch 3: ${ex13.toString()}`" v-model="ex13" dark></v-switch>
-            <v-switch v-bind:label="`Switch 4: ${ex14.toString()}`" v-model="ex14" dark></v-switch>
-          </v-card-text>
-        </v-card>
-      </v-flex>
-    </v-layout>
+    <v-switch v-bind:label="`Switch 1: ${ex11.toString()}`" v-model="ex11"></v-switch>
+    <v-switch v-bind:label="`Switch 2: ${ex12.toString()}`" v-model="ex12"></v-switch>
   </v-container>
 </template>
 
@@ -28,9 +10,7 @@
     data () {
       return {
         ex11: true,
-        ex12: false,
-        ex13: true,
-        ex14: false,
+        ex12: false
       }
     }
   }

--- a/examples/selection-controls/switchesStates.vue
+++ b/examples/selection-controls/switchesStates.vue
@@ -1,71 +1,27 @@
 <template>
   <v-container fluid>
+    <v-layout row wrap class="dark--text">
+      <v-flex xs6>on</v-flex>
+      <v-flex xs6>off</v-flex>
+    </v-layout>
     <v-layout row wrap>
-      <v-flex xs12 md6>
-        <v-subheader>Light</v-subheader>
-        <v-card flat>
-          <v-card-text>
-            <v-container fluid>
-              <v-layout row wrap class="dark--text">
-                <v-flex xs6>on</v-flex>
-                <v-flex xs6>off</v-flex>
-              </v-layout>
-              <v-layout row wrap>
-                <v-flex xs6>
-                  <v-switch value input-value="true" ></v-switch>
-                </v-flex>
-                <v-flex xs6>
-                  <v-switch ></v-switch>
-                </v-flex>
-              </v-layout>
-              <v-layout row wrap class="dark--text">
-                <v-flex xs6>on disabled</v-flex>
-                <v-flex xs6>off disabled</v-flex>
-              </v-layout>
-              <v-layout row wrap>
-                <v-flex xs6>
-                  <v-switch value input-value="true" disabled></v-switch>
-                </v-flex>
-                <v-flex xs6>
-                  <v-switch disabled></v-switch>
-                </v-flex>
-              </v-layout>
-            </v-container>
-          </v-card-text>
-        </v-card>
+      <v-flex xs6>
+        <v-switch value input-value="true" ></v-switch>
       </v-flex>
-      <v-flex xs12 md6>
-        <v-subheader>Dark</v-subheader>
-        <v-card color="grey darken-3" flat dark>
-          <v-card-text>
-            <v-container fluid>
-              <v-layout row wrap class="light--text">
-                <v-flex xs6>on</v-flex>
-                <v-flex xs6>off</v-flex>
-              </v-layout>
-              <v-layout row wrap>
-                <v-flex xs6>
-                  <v-switch value input-value="true"></v-switch>
-                </v-flex>
-                <v-flex xs6>
-                  <v-switch></v-switch>
-                </v-flex>
-              </v-layout>
-              <v-layout row wrap class="light--text">
-                <v-flex xs6>on disabled</v-flex>
-                <v-flex xs6>off disabled</v-flex>
-              </v-layout>
-              <v-layout row wrap>
-                <v-flex xs6>
-                  <v-switch value input-value="true" disabled></v-switch>
-                </v-flex>
-                <v-flex xs6>
-                  <v-switch disabled></v-switch>
-                </v-flex>
-              </v-layout>
-            </v-container>
-          </v-card-text>
-        </v-card>
+      <v-flex xs6>
+        <v-switch ></v-switch>
+      </v-flex>
+    </v-layout>
+    <v-layout row wrap class="dark--text">
+      <v-flex xs6>on disabled</v-flex>
+      <v-flex xs6>off disabled</v-flex>
+    </v-layout>
+    <v-layout row wrap>
+      <v-flex xs6>
+        <v-switch value input-value="true" disabled></v-switch>
+      </v-flex>
+      <v-flex xs6>
+        <v-switch disabled></v-switch>
       </v-flex>
     </v-layout>
   </v-container>

--- a/i18n/en-US/components/SelectionControls.js
+++ b/i18n/en-US/components/SelectionControls.js
@@ -5,23 +5,19 @@ export default {
   examples: [{
     example: {
       header: 'Default examples',
-      desc: '',
-      uninverted: true
+      desc: ''
     },
     checkboxesBoolean: {
       header: "Checkboxes - Boolean",
-      desc: '',
-      uninverted: true
+      desc: ''
     },
     checkboxesArray: {
       header: "Checkboxes - Array",
-      desc: '',
-      uninverted: true
+      desc: ''
     },
     checkboxesStates: {
       header: "Checkboxes - States",
-      desc: '',
-      uninverted: true
+      desc: ''
     },
     checkboxesColors: {
       header: "Checkboxes - Colors",
@@ -29,13 +25,11 @@ export default {
     },
     radiosDefault: {
       header: "Radios - Default",
-      desc: 'Radio-groups are by default mandatory. This can be changed with the <code>mandatory</code> prop.',
-      uninverted: true
+      desc: 'Radio-groups are by default mandatory. This can be changed with the <code>mandatory</code> prop.'
     },
     radiosDirection: {
       header: "Radios - Direction",
-      desc: 'Radio-groups can be presented either as a row or a column, using their respective props. The default is as a column.',
-      uninverted: true
+      desc: 'Radio-groups can be presented either as a row or a column, using their respective props. The default is as a column.'
     },
     radiosColors: {
       header: "Radios - Colors",
@@ -43,18 +37,15 @@ export default {
     },
     switchesBoolean: {
       header: "Switches - Boolean",
-      desc: '',
-      uninverted: true
+      desc: ''
     },
     switchesArray: {
       header: "Switches - Array",
-      desc: '',
-      uninverted: true
+      desc: ''
     },
     switchesStates: {
       header: "Switches - States",
-      desc: '',
-      uninverted: true
+      desc: ''
     },
     switchesColors: {
       header: "Switches - Colors",

--- a/i18n/en-US/components/TextFields.js
+++ b/i18n/en-US/components/TextFields.js
@@ -41,11 +41,11 @@ export default {
     },
     hint: {
       header: 'Hint text',
-      desc: 'Light theme'
+      desc: 'The **hint** property on text-fields adds the provided string beneath the text-field. Using **persistent-hint** keeps the hint visible when the text-field is not focused.'
     },
     prefixesAndSuffixes: {
       header: 'Prefixes & suffixes',
-      desc: 'Light theme'
+      desc: 'The **prefix** and **suffix** property allows you to prepend and append inline non-modifiable text next to the text-field'
     },
     customValidation: {
       header: 'Custom validation',


### PR DESCRIPTION
A pull request addressing issues #53 and #55.

    dark/light theme on selection-controls examples can be a 'invert color' button #53
    https://github.com/vuetifyjs/vuetifyjs.com/issues/53

    Update text-fields examples descriptions #55
    https://github.com/vuetifyjs/vuetifyjs.com/issues/55
