### PR TITLE
enhancement/grid

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -1,3 +1,9 @@
+/*
+ * THIS FILE HAS BEEN AUTOMATICALLY GENERATED USING THE VUETIFY-HELPER-JSON TOOL.
+ *
+ * CHANGES MADE TO THIS FILE WILL BE LOST!
+ */
+
 module.exports = {
   "v-app": {
     "props": [
@@ -966,21 +972,15 @@ module.exports = {
   "v-carousel-item": {
     "props": [
       {
-        "name": "reverseTransition",
-        "type": "String",
-        "default": "tab-reverse-transition",
-        "source": null
-      },
-      {
-        "name": "src",
-        "type": "String",
-        "default": "undefined",
-        "source": null
-      },
-      {
         "name": "transition",
         "type": "String",
         "default": "tab-transition",
+        "source": null
+      },
+      {
+        "name": "reverseTransition",
+        "type": "String",
+        "default": "tab-reverse-transition",
         "source": null
       }
     ],
@@ -2143,6 +2143,18 @@ module.exports = {
   "v-container": {
     "props": [
       {
+        "name": "grid-list-{xs through xl}",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "fluid",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
         "name": "id",
         "type": "String",
         "default": "undefined",
@@ -2152,6 +2164,114 @@ module.exports = {
         "name": "tag",
         "type": "String",
         "default": "div",
+        "source": null
+      },
+      {
+        "name": "alignBaseline",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "alignCenter",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "alignContentCenter",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "alignContentEnd",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "alignContentSpaceAround",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "alignContentSpaceBetween",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "alignContentStart",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "alignEnd",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "alignStart",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "d-{type}",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "fillHeight",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "justifyCenter",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "justifyEnd",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "justifySpaceAround",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "justifySpaceBetween",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "justifyStart",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "reverse",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "wrap",
+        "type": "Boolean",
+        "default": "false",
         "source": null
       }
     ],
@@ -2160,6 +2280,24 @@ module.exports = {
   "v-flex": {
     "props": [
       {
+        "name": "offset-(size)(0-12)",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "order-(size)(0-12)",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "(size)(1-12)",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
         "name": "id",
         "type": "String",
         "default": "undefined",
@@ -2169,6 +2307,114 @@ module.exports = {
         "name": "tag",
         "type": "String",
         "default": "div",
+        "source": null
+      },
+      {
+        "name": "alignBaseline",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "alignCenter",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "alignContentCenter",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "alignContentEnd",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "alignContentSpaceAround",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "alignContentSpaceBetween",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "alignContentStart",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "alignEnd",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "alignStart",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "d-{type}",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "fillHeight",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "justifyCenter",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "justifyEnd",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "justifySpaceAround",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "justifySpaceBetween",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "justifyStart",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "reverse",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "wrap",
+        "type": "Boolean",
+        "default": "false",
         "source": null
       }
     ],
@@ -2177,6 +2423,18 @@ module.exports = {
   "v-layout": {
     "props": [
       {
+        "name": "row",
+        "type": "Boolean",
+        "default": "true",
+        "source": null
+      },
+      {
+        "name": "column",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
         "name": "id",
         "type": "String",
         "default": "undefined",
@@ -2186,6 +2444,114 @@ module.exports = {
         "name": "tag",
         "type": "String",
         "default": "div",
+        "source": null
+      },
+      {
+        "name": "alignBaseline",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "alignCenter",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "alignContentCenter",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "alignContentEnd",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "alignContentSpaceAround",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "alignContentSpaceBetween",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "alignContentStart",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "alignEnd",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "alignStart",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "d-{type}",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "fillHeight",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "justifyCenter",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "justifyEnd",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "justifySpaceAround",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "justifySpaceBetween",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "justifyStart",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "reverse",
+        "type": "Boolean",
+        "default": "false",
+        "source": null
+      },
+      {
+        "name": "wrap",
+        "type": "Boolean",
+        "default": "false",
         "source": null
       }
     ],
@@ -4336,6 +4702,10 @@ module.exports = {
     "mixins": [
       "positionable",
       "toggleable"
+    ],
+    "slots": [
+      "activator",
+      "default"
     ]
   },
   "v-stepper": {

--- a/components/helpers/Parameters.vue
+++ b/components/helpers/Parameters.vue
@@ -71,10 +71,10 @@
         let devPrepend = ''
         const camelSource = camel(item.source)
 
-        const specialLevelDesc = `${this.namespace}.${this.type}.${this.target}.${name}`
-        const componentLevelDesc = `${this.namespace}.${this.type}.${name}`
-        const mixinDesc = `Mixins.${camelSource}.${this.type}.${name}`
-        const genericDesc = `Generic.${capitalize(this.type)}.${name}`
+        const specialLevelDesc = `${this.namespace}.${this.type}.${this.target}['${name}']`
+        const componentLevelDesc = `${this.namespace}.${this.type}['${name}']`
+        const mixinDesc = `Mixins.${camelSource}.${this.type}['${name}']`
+        const genericDesc = `Generic.${capitalize(this.type)}['${name}']`
 
         if (this.$te(specialLevelDesc)) {
           description = this.$t(specialLevelDesc)

--- a/examples/grid/grid.vue
+++ b/examples/grid/grid.vue
@@ -6,27 +6,27 @@
           <v-card-text class="px-0">12</v-card-text>
         </v-card>
       </v-flex>
-      <v-flex xs6 v-for="i in 2" :key="i">
+      <v-flex xs6 v-for="i in 2" :key="`6${i}`">
         <v-card dark color="secondary">
           <v-card-text class="px-0">6</v-card-text>
         </v-card>
       </v-flex>
-      <v-flex xs4 v-for="i in 3" :key="i">
+      <v-flex xs4 v-for="i in 3" :key="`4${i}`">
         <v-card dark color="primary">
           <v-card-text class="px-0">4</v-card-text>
         </v-card>
       </v-flex>
-      <v-flex xs3 v-for="i in 4" :key="i">
+      <v-flex xs3 v-for="i in 4" :key="`3${i}`">
         <v-card dark color="secondary">
           <v-card-text class="px-0">3</v-card-text>
         </v-card>
       </v-flex>
-      <v-flex xs2 v-for="i in 6" :key="i">
+      <v-flex xs2 v-for="i in 6" :key="`2${i}`">
         <v-card dark color="primary">
           <v-card-text class="px-0">2</v-card-text>
         </v-card>
       </v-flex>
-      <v-flex xs1 v-for="i in 12" :key="i">
+      <v-flex xs1 v-for="i in 12" :key="`1${i}`">
         <v-card dark color="secondary">
           <v-card-text class="px-0">1</v-card-text>
         </v-card>

--- a/lang/en/components/Grid.js
+++ b/lang/en/components/Grid.js
@@ -48,7 +48,38 @@ export default {
     }
   }],
   props: {
-    tag: 'Mixins.Routable.props.tag'
+    tag: 'Mixins.Routable.props.tag',
+    alignBaseline: 'Align items to the baseline.',
+    alignCenter: 'Align items to the center.',
+    alignContentCenter: 'Align content to the center.',
+    alignContentEnd: 'Align content to the end.',
+    alignContentSpaceAround: 'Align content to the space around.',
+    alignContentSpaceBetween: 'Align content to the space between.',
+    alignContentStart: 'Align content to the start.',
+    alignEnd: 'Align items to the end.',
+    alignStart: 'Align items to the start.',
+    'd-{type}': 'Specify to display an element as flex/inline-flex/block etc. Syntax is `d-{type}`. For example `d-flex`.',
+    fillHeight: 'Make sure that col element height is filled with parent and child. Important for Safari/Firefox if children is column element.',
+    justifyCenter: 'Justify content to the center.',
+    justifyEnd: 'Justify content to the end.',
+    justifySpaceAround: 'Justify content to the space around.',
+    justifySpaceBetween: 'Justify content to the space between.',
+    justifyStart: 'Justify content to the start.',
+    reverse: 'Reverses the currently selected direction (column, row).',
+    wrap: 'Allows children to wrap within the container if the elements use more than 100%.',
+    'v-container': {
+      'grid-list-{xs through xl}': 'Sets the gutter between grid list items ranging from 2px to 24px',
+      fluid: 'Removes viewport size breakpoints'
+    },
+    'v-flex': {
+      'offset-(size)(1-12)': 'offset-xs: extra small, offset-sm: small, offset-md: medium, offset-lg: large, offset-xl: extra large. Example: offset-xs3',
+      'order-(size)(1-12)': 'order-xs: extra small, order-sm: small, order-md: medium, order-lg: large, order-xl: extra large. Example: order-xs3',
+      '(size)(1-12)': 'xs: extra small, sm: small, md: medium, lg: large, xl: extra large - 1 through 12',
+    },
+    'v-layout': {
+      row: 'Sets flex direction to row',
+      column: 'Sets flex direction to column'
+    }
   },
   breakpointHeader: 'Breakpoint object',
   breakpointText1: 'Vuetify converts the available breakpoints into an accessible object from within your application. This will allow you to assign/apply specific properties and attributes based upon viewport size. The object can be accessed from:',


### PR DESCRIPTION
Replicated grid changes from https://github.com/vuetifyjs/vuetifyjs.com/pull/159 (thanks @MustafaHussaini)

- no need for `textToDisplay` prop. Parameters component now properly handles irregular prop names such as `grid-list-{xs through xl}`

- generated new api file

- added prop descriptions

- fixed grid example key duplication