### PR TITLE
Update expansion list example to show how to use v-model to expand a group.

### DIFF
--- a/examples/lists/expansionLists.vue
+++ b/examples/lists/expansionLists.vue
@@ -12,6 +12,7 @@
         </v-toolbar>
         <v-list>
           <v-list-group
+            v-model="item.active"
             v-for="item in items"
             :key="item.title"
             :prepend-icon="item.action"


### PR DESCRIPTION
This PR follows a discussion in #need-help Feb 12 at midnight Eastern time where a user could not determine how to have a list opened by default.  This one-line change causes the second list group to be opened (it was already setting `active=true` for that item).

I think this commit only adds additional information to the documentation, although as far as I can tell, the actual text documentation is missing all coverage of `v-list-group` entirely, or we might be able to document that specifying a `v-model` controls whether it is expanded or not.  At least this small change shows how to do this in the example code.

This small change is unsolicited and you might prefer to have them all closed by default, but in that case I'd suggest just setting `active=false` in the second item and adding a comment to it that says it controls whether the group is expanded, since `v-model` references `active` .  (I could do that PR instead if you prefer.)