### PR TITLE
fixed closing tag error on quick start page.

### DIFF
--- a/pages/getting-started/QuickStartPage.vue
+++ b/pages/getting-started/QuickStartPage.vue
@@ -39,7 +39,7 @@
           |     &lt;v-app&gt;
           |       &lt;v-content&gt;
           |         &lt;v-container&gt;Hello world&lt;/v-container&gt;
-          |       &lt;v-content&gt;
+          |       &lt;/v-content&gt;
           |     &lt;/v-app&gt;
           |   &lt;/div&gt;
           | &nbsp;


### PR DESCRIPTION
Missing closing tag on the <v-content> component on getting started, quick start page of the docs. Though't I'd hop in and fix a quick mistake :)
![screen shot 2018-02-13 at 3 15 30 pm](https://user-images.githubusercontent.com/20526900/36171462-c3e1df82-10d0-11e8-9ab9-56948c4fdb04.png)
