### PR TITLE
Add meta fields for social cards

### DIFF
--- a/assets/index.template.html
+++ b/assets/index.template.html
@@ -6,6 +6,10 @@
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui">
     <meta name="description" content="{{ description }}">
+    <meta name="twitter:card" content="https://vuetifyjs.com/static/vuetify-logo-300.png">
+    <meta property="og:title" content="{{ title }}">
+    <meta property="og:description" content="{{ description }}">
+    <meta property="og:image" content="https://vuetifyjs.com/static/vuetify-logo-300.png">
     <meta name="keywords" content="{{ keywords }}">
     <link rel="shortcut icon" href="/static/favicon.ico">
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" crossorigin="anonymous">


### PR DESCRIPTION
Fixes vuetifyjs.com links being shared on social media sites (facebook/twitter) not displaying the preview cards correctly.

This fix was based on: https://css-tricks.com/essential-meta-tags-social-media/#article-header-id-6