### PR TITLE
Removed unused 'bottom' attribute from v-select example

### DIFF
--- a/examples/selects/light.vue
+++ b/examples/selects/light.vue
@@ -10,7 +10,6 @@
           v-model="e1"
           label="Select"
           single-line
-          bottom
         ></v-select>
       </v-flex>
       <v-flex xs6>


### PR DESCRIPTION
'v-select' props mixin in [here](https://github.com/vuetifyjs/vuetify/blob/dev/src/components/VSelect/mixins/select-props.js) does not seem to contain any information about attribute named 'bottom', 
I suppose it's just a left-over, so I've removed it.