### PR TITLE
change the default value of browser-autocomplete to 'off'

### DIFF
--- a/lang/en/components/Selects.js
+++ b/lang/en/components/Selects.js
@@ -44,7 +44,7 @@ export default {
   props: {
     attach: 'Mixins.Detachable.props.attach',
     autocomplete: 'Filter the items in the list based on user input',
-    browserAutocomplete: 'Set the autocomplete prop for the search input when using the **autocomplete** prop',
+    browserAutocomplete: 'Set browser autocompletion for the search input',
     cacheItems: 'Keeps a local _unique_ copy of all items that have been passed through the **items** prop.',
     chips: 'Changes display of selections to chips',
     combobox: 'The single select variant of **tags**',

--- a/lang/zhHans/components/Selects.js
+++ b/lang/zhHans/components/Selects.js
@@ -44,7 +44,7 @@ export default {
   props: {
     attach: 'Mixins.Detachable.props.attach',
     autocomplete: '根据用户输入进行筛选',
-    browserAutocomplete: '当使用 **autocomplete** 属性时为搜索框设置自动补全属性',
+    browserAutocomplete: '设置搜索框的浏览器自动补全',
     cacheItems: '保留已经通过 **items** 属性的项在本地的唯一副本',
     chips: '改变一个已选择项为小纸片（chips）的显示方式',
     combobox: '在单选中 **tags** 的一个变种',


### PR DESCRIPTION
This change is related to [this pull request](https://github.com/vuetifyjs/vuetify/pull/3635) and this [issue](https://github.com/vuetifyjs/vuetify/issues/3582).

Currently the docs for this prop says 'Set the autocomplete prop for the search input when using the autocomplete prop', but I feel like this is not very accurate since it has little to do with the `autocomplete` prop of this component. Maybe something like 'Set browser autocompletion for the search input' is better?