### PR TITLE
Feat: Make Discord more visible

### DIFF
--- a/components/core/AppToolbar.vue
+++ b/components/core/AppToolbar.vue
@@ -117,6 +117,35 @@
             v-list-tile-content
               v-list-tile-title {{ social.text }}
 
+      v-toolbar-items
+      v-menu(
+        attach
+        bottom
+        left
+        offset-y
+        max-height="500"
+        v-show="!isStore"
+      )
+        v-btn(
+          flat
+          slot="activator"
+          style="min-width: 64px"
+        )
+          span.hidden-sm-and-down {{ $t('Vuetify.AppToolbar.support' )}}
+          v-icon(:right="$vuetify.breakpoint.mdAndUp") mdi-lifebuoy
+        v-list(light)
+          v-list-tile(
+            target="_blank"
+            rel="noopener"
+            v-for="support in supports"
+            :href="support.href"
+            :key="support.text"
+          )
+            v-list-tile-action
+              v-icon(light) {{ support.icon }}
+            v-list-tile-content
+              v-list-tile-title {{ support.text }}
+
       v-menu(
         bottom
         left
@@ -170,6 +199,7 @@
 
     data: vm => ({
       ecosystems: vm.$t('Vuetify.AppToolbar.ecosystems'),
+      supports: vm.$t('Vuetify.AppToolbar.supports'),
       fixed: false,
       languages,
       socials: vm.$t('Vuetify.AppToolbar.socials')

--- a/lang/en/vuetify/AppToolbar.js
+++ b/lang/en/vuetify/AppToolbar.js
@@ -3,13 +3,31 @@ export default {
   cart: 'Cart',
   docs: 'Docs',
   documentation: 'Documentation',
-  ecosystem: 'Ecosystem',
-  ecosystems: [
+  support: 'Support',
+  supports: [
     {
       href: 'https://community.vuetifyjs.com/',
-      text: 'Community',
-      icon: 'mdi-account-multiple'
+      text: 'Chat',
+      icon: 'mdi-discord'
     },
+    {
+      href: 'https://issues.vuetifyjs.com',
+      text: 'Create an Issue',
+      icon: 'mdi-alert-octagon'
+    },
+    {
+      href: 'https://github.com/vuetifyjs/vuetify/issues',
+      text: 'GitHub Issue board',
+      icon: 'mdi-github-face'
+    },
+    {
+      href: 'https://stackoverflow.com/search?q=vuetify',
+      text: 'Stack overflow',
+      icon: 'mdi-stack-overflow'
+    }
+  ],
+  ecosystem: 'Ecosystem',
+  ecosystems: [
     {
       href: 'https://www.reddit.com/r/vuetifyjs/',
       text: 'Reddit',
@@ -26,11 +44,6 @@ export default {
       icon: 'mdi-creation'
     },
     {
-      href: 'https://issues.vuetifyjs.com',
-      text: 'Create an Issue',
-      icon: 'mdi-alert-octagon'
-    },
-    {
       href: 'https://template.vuetifyjs.com',
       text: 'Codepen Template',
       icon: 'mdi-codepen'
@@ -39,16 +52,6 @@ export default {
       href: 'https://github.com/vuetifyjs/vuetify/releases',
       text: 'Latest Releases',
       icon: 'mdi-format-list-checks'
-    },
-    {
-      href: 'https://github.com/vuetifyjs/vuetify/issues',
-      text: 'GitHub Issue board',
-      icon: 'mdi-github-face'
-    },
-    {
-      href: 'https://stackoverflow.com/search?q=vuetify',
-      text: 'Stack overflow',
-      icon: 'mdi-stack-overflow'
     }
   ],
   quickLinks: 'Quick Links',

--- a/lang/en/vuetify/Home.js
+++ b/lang/en/vuetify/Home.js
@@ -3,6 +3,7 @@ export default {
   heading1: 'Vuetify',
   heading1cont: 'Material Component Framework',
   getStarted: 'Get Started',
+  getHelp: 'Get Help',
   features: [
     {
       img: '/static/doc-images/feature1.svg',

--- a/lang/ja/vuetify/Home.js
+++ b/lang/ja/vuetify/Home.js
@@ -3,6 +3,7 @@ export default {
   heading1: 'Vuetify',
   heading1cont: 'Material Component Framework',
   getStarted: 'はじめる',
+  getHelp: '助けて',
   features: [
     {
       img: '/static/doc-images/feature1.svg',

--- a/lang/ko/vuetify/AppToolbar.js
+++ b/lang/ko/vuetify/AppToolbar.js
@@ -3,13 +3,31 @@ export default {
   cart: '장바구니',
   docs: '문서',
   documentation: '문서',
-  ecosystem: '생태계',
-  ecosystems: [
+  support: '지원하다',
+  supports: [
     {
       href: 'https://community.vuetifyjs.com/',
-      text: '커뮤니티',
-      icon: 'mdi-account-multiple'
+      text: '잡담',
+      icon: 'mdi-discord'
     },
+    {
+      href: 'https://issues.vuetifyjs.com',
+      text: '이슈 만들기',
+      icon: 'mdi-alert-octagon'
+    },
+    {
+      href: 'https://github.com/vuetifyjs/vuetify/issues',
+      text: '깃헙 이슈 보드',
+      icon: 'mdi-github-face'
+    },
+    {
+      href: 'https://stackoverflow.com/search?q=vuetify',
+      text: '스택오버플로우',
+      icon: 'mdi-stack-overflow'
+    }
+  ],
+  ecosystem: '생태계',
+  ecosystems: [
     {
       href: 'https://www.reddit.com/r/vuetifyjs/',
       text: 'Reddit',
@@ -26,11 +44,6 @@ export default {
       icon: 'mdi-creation'
     },
     {
-      href: 'https://issues.vuetifyjs.com',
-      text: '이슈 만들기',
-      icon: 'mdi-alert-octagon'
-    },
-    {
       href: 'https://template.vuetifyjs.com',
       text: 'Codepen 템플릿',
       icon: 'mdi-codepen'
@@ -39,16 +52,6 @@ export default {
       href: 'https://github.com/vuetifyjs/vuetify/releases',
       text: '최근 릴리즈',
       icon: 'mdi-format-list-checks'
-    },
-    {
-      href: 'https://github.com/vuetifyjs/vuetify/issues',
-      text: '깃헙 이슈 보드',
-      icon: 'mdi-github-face'
-    },
-    {
-      href: 'https://stackoverflow.com/search?q=vuetify',
-      text: '스택오버플로우',
-      icon: 'mdi-stack-overflow'
     }
   ],
   quickLinks: '빠른 링크',

--- a/lang/ko/vuetify/Home.js
+++ b/lang/ko/vuetify/Home.js
@@ -3,6 +3,7 @@ export default {
   heading1: 'Vuetify',
   heading1cont: '마티리얼 컴포넌트 프레임워크',
   getStarted: '시작하기',
+  getHelp: '도움',
   features: [
     {
       img: '/static/doc-images/feature1.svg',

--- a/lang/ru/vuetify/AppToolbar.js
+++ b/lang/ru/vuetify/AppToolbar.js
@@ -3,13 +3,31 @@ export default {
   cart: 'Cart',
   docs: 'Док',
   documentation: 'Документация',
-  ecosystem: 'Экосистема',
-  ecosystems: [
+  support: 'поддержка',
+  supports: [
     {
       href: 'https://community.vuetifyjs.com/',
-      text: 'Сообщество',
-      icon: 'mdi-account-multiple'
+      text: 'чат',
+      icon: 'mdi-dicord'
     },
+    {
+      href: 'https://issues.vuetifyjs.com',
+      text: 'Создать Issue',
+      icon: 'mdi-alert-octagon'
+    },
+    {
+      href: 'https://github.com/vuetifyjs/vuetify/issues',
+      text: 'Github Issue board',
+      icon: 'mdi-github-face'
+    },
+    {
+      href: 'https://stackoverflow.com/search?q=vuetify',
+      text: 'Stack overflow',
+      icon: 'mdi-stack-overflow'
+    }
+  ],
+  ecosystem: 'Экосистема',
+  ecosystems: [
     {
       href: 'https://www.reddit.com/r/vuetifyjs/',
       text: 'Reddit',
@@ -26,11 +44,6 @@ export default {
       icon: 'mdi-creation'
     },
     {
-      href: 'https://issues.vuetifyjs.com',
-      text: 'Создать Issue',
-      icon: 'mdi-alert-octagon'
-    },
-    {
       href: 'https://template.vuetifyjs.com',
       text: 'Шаблоны в Codepen',
       icon: 'mdi-codepen'
@@ -39,16 +52,6 @@ export default {
       href: 'https://github.com/vuetifyjs/vuetify/releases',
       text: 'Последние релизы',
       icon: 'mdi-format-list-checks'
-    },
-    {
-      href: 'https://github.com/vuetifyjs/vuetify/issues',
-      text: 'Github Issue board',
-      icon: 'mdi-github-face'
-    },
-    {
-      href: 'https://stackoverflow.com/search?q=vuetify',
-      text: 'Stack overflow',
-      icon: 'mdi-stack-overflow'
     }
   ],
   quickLinks: 'Быстрые ссылки',

--- a/lang/ru/vuetify/Home.js
+++ b/lang/ru/vuetify/Home.js
@@ -3,6 +3,7 @@ export default {
   heading1: 'Vuetify',
   heading1cont: 'Material Component Framework',
   getStarted: 'Начать изучение',
+  getHelp: 'Помогите',
   features: [
     {
       img: '/static/doc-images/feature1.svg',

--- a/lang/zhHans/vuetify/Home.js
+++ b/lang/zhHans/vuetify/Home.js
@@ -3,6 +3,7 @@ export default {
   'heading1': 'Vuetify',
   'heading1cont': 'Material Design 组件框架',
   'getStarted': '快速入门',
+  'getHelp': '帮帮我',
   'features': [
     {
       'img': '/static/doc-images/feature1.svg',

--- a/pages/HomePage.vue
+++ b/pages/HomePage.vue
@@ -45,9 +45,10 @@
               v-icon(left) mdi-github-circle
               | Github
             v-btn(
-              color="dark"
+              color="white"
               href="https://community.vuetifyjs.com"
               large
+              outline
               rel="noopener"
               target="_blank"
             )

--- a/pages/HomePage.vue
+++ b/pages/HomePage.vue
@@ -44,6 +44,15 @@
             )
               v-icon(left) mdi-github-circle
               | Github
+            v-btn(
+              color="dark"
+              href="https://community.vuetifyjs.com"
+              large
+              rel="noopener"
+              target="_blank"
+            )
+              v-icon(left) mdi-discord
+              | {{ $t("Vuetify.Home.getHelp") }}
 
       v-container(
         grid-list-xl
@@ -260,6 +269,11 @@
           icon: 'mdi-facebook',
           href: 'https://www.facebook.com/vuetifyjs',
           title: 'Facebook'
+        },
+        {
+          icon: 'mdi-discord',
+          href: 'https://community.vuetifyjs.com',
+          title: 'Discord Community'
         }
       ]
     }),


### PR DESCRIPTION
While at vueconf it was noticed that the community and support aspect of using discord and other support options was not very clear. I have made modifications to the front page and toolbar that makes this clearer and hopefully allows more users to engage with the community.

1. Added `Get Help` button in jumbotron
2. Added discord link in social links on home page
3. Separated support items to a support dropdown and out of ecosystem dropdowm.
4. Renamed community link that was in ecosystem to `chat` that is now in support.