### PR TITLE
Add vuetify build process on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ yarn dev
 ``` bash
 git clone https://github.com/vuetifyjs/vuetify.git
 yarn
+yarn build
 yarn link
 yarn watch
 ```


### PR DESCRIPTION
Vuetify need to be `yarn build` at least one time before `yarn link` it to docs