### PR TITLE
Fix package name for npm command

### DIFF
--- a/src/pages/getting-started/QuickStartPage.vue
+++ b/src/pages/getting-started/QuickStartPage.vue
@@ -28,7 +28,7 @@
         markup(lang="bash")
           | $ yarn global add @vue/cli
           | // OR
-          | $ npm install vue-cli -g
+          | $ npm install @vue/cli -g
 
         app-alert(info :value="`${namespace}.vueCliText2`")
 


### PR DESCRIPTION
Use the new package name @vue/cli instead of vue-cli for NPM command