### PR TITLE
#549 Update link, use docs link instead of github for easier readability

### DIFF
--- a/src/lang/en/getting-started/QuickStart.json
+++ b/src/lang/en/getting-started/QuickStart.json
@@ -4,7 +4,7 @@
   "vueCliHeader": "Vue CLI-3 Install",
   "vueCliText1": "Vue-CLI 3 is the next generation cli tool made to help you get started more easily than before. When you start your app with vue-cli you will also be able to get the official webpack updates and config changes, as well as Vuetify's updates without an arduous upgrade process.",
   "vueCliText2": "For information on how to use Vue-CLI-3, visit the [official documentation](https://cli.vuejs.org/guide/)",
-  "vueCliText3": "**Tip**: If you don't want to overwrite your current vue-cli because you still need vue init from version 2, then [try this](https://github.com/vuejs/vue-cli/blob/dev/docs/cli.md#pulling-vue-cli2x-templates-legacy).",
+  "vueCliText3": "**Tip**: If you don't want to overwrite your current vue-cli because you still need vue init from version 2, then [try this](https://cli.vuejs.org/guide/creating-a-project.html#pulling-2-x-templates-legacy).",
   "vueCliText4": "Once the cli is installed, you can generate a new project scaffold. Select the _default install_ unless you have specific packages that you need to include (e.g. _vuex_ or _vue-router_). This will create a new Vue project that's ready to go with your selected options.",
   "vueCliText5": "Now that you have an instantiated project, you can add the **[Vuetify package](https://github.com/vuetifyjs/vue-cli-plugin-vuetify)** using the cli.",
   "vueCliText6": "Keep in mind, if you are installing the Vuetify package on an _existing_ vue-cli-3 project, ensure you have a clean working directory in case there are issues with the merge.",


### PR DESCRIPTION
Solves https://github.com/vuetifyjs/vuetifyjs.com/issues/549 

Is decided to use the official Documentation link instead of Github, because it's much easier to read. There is a link from there to github too if you really want to view the file, but not the other way around.