### PR TITLE
Typo in component's name (alacarte component's list)

### DIFF
--- a/src/util/alacarteComponents.js
+++ b/src/util/alacarteComponents.js
@@ -62,7 +62,7 @@ export default function alacarteComponents () {
     { name: 'v-snackbar', component: 'VSnackbar', group: 'VSnackbar' },
     { name: 'v-speed-dial', component: 'VSpeedDial', group: 'VSpeedDial' },
     { name: 'v-stepper', component: 'VStepper', group: 'VStepper' },
-    { name: 'v-stepper-content', component: 'VStepperCotent', group: 'VStepper' },
+    { name: 'v-stepper-content', component: 'VStepperContent', group: 'VStepper' },
     { name: 'v-stepper-step', component: 'VStepperStep', group: 'VStepper' },
     { name: 'v-subheader', component: 'VSubheader', group: 'VSubheader' },
     { name: 'v-switch', component: 'VSwitch', group: 'VSwitch' },


### PR DESCRIPTION
There's a typo in "VStepperCotent"   => VStepperContent