### PR TITLE
FIX: Autocomplete API should only request once

### DIFF
--- a/src/examples/autocompletes/api.vue
+++ b/src/examples/autocompletes/api.vue
@@ -97,7 +97,7 @@
       search (val) {
         // Items have already been loaded
         if (this.items.length > 0) return
-        
+
         // Items have already been requested
         if (this.isLoading) return
 

--- a/src/examples/autocompletes/api.vue
+++ b/src/examples/autocompletes/api.vue
@@ -97,6 +97,9 @@
       search (val) {
         // Items have already been loaded
         if (this.items.length > 0) return
+        
+        // Items have already been requested
+        if (this.isLoading) return
 
         this.isLoading = true
 


### PR DESCRIPTION
Multiple requests are made to the API with each character the user types before the initial request is returned and processed.

Pen with demonstration of the problem:
https://codepen.io/jaxn615/pen/gdYzVO