### PR TITLE
refactor(data-tables): use immediate instead of mounted

### DIFF
--- a/src/examples/data-tables/server.vue
+++ b/src/examples/data-tables/server.vue
@@ -52,15 +52,9 @@
               this.totalDesserts = data.total
             })
         },
-        deep: true
+        deep: true,
+        immediate: true
       }
-    },
-    mounted () {
-      this.getDataFromApi()
-        .then(data => {
-          this.desserts = data.items
-          this.totalDesserts = data.total
-        })
     },
     methods: {
       getDataFromApi () {


### PR DESCRIPTION
> // the callback will be called immediately after the start of the observation

https://vuejs.org/v2/api/#watch

Instead of `mounted` the watch could be triggered `immediate` to avoid code duplication.  
If there's a good reason to use `mounted` (i.e. because it will trigger sooner which might be important) the reason could be added here as a comment.