### PR TITLE
Fixed doc for ExpansionPanels about the expand prop. Fixes #602

### DIFF
--- a/src/lang/en/components/ExpansionPanels.json
+++ b/src/lang/en/components/ExpansionPanels.json
@@ -1,6 +1,6 @@
 {
   "header": "Expansion Panel",
-  "headerText": "The `v-expansion-panel` component is useful for reducing vertical space with large amounts of information. The default functionality of the component is to only display one expansion-panel body at a time, however, with the `expandable` property, the expansion-panel can remain open until explicitly closed.",
+  "headerText": "The `v-expansion-panel` component is useful for reducing vertical space with large amounts of information. The default functionality of the component is to only display one expansion-panel body at a time, however, with the `expand` property, the expansion-panel can remain open until explicitly closed.",
   "examples": {
     "accordion": {
       "header": "Accordion",


### PR DESCRIPTION
The sentence about the expand functionality on the ExpansionPanels component was mentioning an `expandable` prop, which doesn't exist. The correct prop is called `expand`.