### PR TITLE
feat: add component icons to framework/icons

### DIFF
--- a/src/lang/en/framework/Icons.json
+++ b/src/lang/en/framework/Icons.json
@@ -26,5 +26,7 @@
   "reusableText1": "Vuetify will _automatically_ merge any icon strings provided into the pool of available presets. This allows you to create custom strings that can be utilized in your application by simply referencing the **global icons**.",
   "reusableText2": "This can help ensure your application is always using a specific icon given a provided string. Here are a few ways that you can use `<v-icon>` with this system.",
   "customComponentHeader": "Custom components",
-  "customComponentText1": "You can utilize the same icon strings in your own custom components. Any time **$vuetify.icons** is passed in through _v-text_, _v-html_ or as text, `<v-icon>` will look up that specified value. This allows you to create customized solutions that are easy to build and easy to manage."
+  "customComponentText1": "You can utilize the same icon strings in your own custom components. Any time **$vuetify.icons** is passed in through _v-text_, _v-html_ or as text, `<v-icon>` will look up that specified value. This allows you to create customized solutions that are easy to build and easy to manage.",
+  "componentIconsHeader": "Component icons",
+  "componentIconsText1": "Instead of provided icon fonts presets you can use your own component icons. You also can switch icons that are used in vuetify component with our own."
 }

--- a/src/pages/framework/IconsPage.vue
+++ b/src/pages/framework/IconsPage.vue
@@ -238,4 +238,24 @@
         |   }
         | &lt;/script&gt;
 
+    section#component-icons
+      helpers-section-head(value="Framework.Icons.componentIconsHeader")
+      helpers-section-text(value="Framework.Icons.componentIconsText1")
+
+      helpers-markup(lang="js")
+        | import Vue from 'vue'
+        | import Vuetify from 'vuetify'
+        | import IconComponent from './IconComponent.vue'
+        |
+        | Vue.use(Vuetify, {
+        |   icons: {
+        |     'product': {
+        |       component: IconComponent, // you can use string here if component is registered globally
+        |       props: { // pass props to your component if needed
+        |         name: 'product'
+        |       }
+        |     }
+        |   }
+        | })
+
 </template>


### PR DESCRIPTION
See https://github.com/vuetifyjs/vuetify/pull/4910

I need help with additions to icons page: https://vuetifyjs.com/en/framework/icons

Here are installation instructions for svg font awesome icon preset.
```js
import Vue from 'vue'
import Vuetify from 'vuetify'
import { library } from '@fortawesome/fontawesome-svg-core'
import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
import { fas } from '@fortawesome/free-solid-svg-icons'

// Register component globally
Vue.component('font-awesome-icon', FontAwesomeIcon)
// Include needed icons.
library.add(fas)

Vue.use(Vuetify, {
  iconfont: 'faSvg',
})
```

Can't find a way to modify demo and template :/.