### PR TITLE
fix locale name for Edge browser

### DIFF
--- a/src/pages/framework/InternationalizationPage.vue
+++ b/src/pages/framework/InternationalizationPage.vue
@@ -30,8 +30,8 @@
         |
         | Vue.use(Vuetify, {
         |   lang: {
-        |     locales: { zhHans, pl, sv },
-        |     current: 'zhHans'
+        |     locales: { 'zh-Hans': zhHans, pl, sv },
+        |     current: 'zh-Hans'
         |   }
         | })
         |


### PR DESCRIPTION
Chrome, Firefox and Safari support both zhHant and zh-Hant format. However, Edge browser does not support zhHant locale name.

This pull request modify the example code to specific key name for locales object.

---

I found this bug at https://github.com/vuetifyjs/vuetify/blob/8296848c953762e5ecac4b7507890e34a1614732/src/mixins/data-iterable.js#L458
 and Edge browser will throw `Locale 'zhHant' is not well-formed`.