### PR TITLE
feat: generate automatcally list of supported languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dotenv": "^5.0.1",
     "es6-promise": "^4.2.4",
     "express": "^4.16.3",
+    "iso-639-1": "^2.0.3",
     "lru-cache": "^4.1.3",
     "memory-fs": "^0.4.1",
     "node-fetch": "^2.1.2",

--- a/src/lang/en/framework/Internationalization.json
+++ b/src/lang/en/framework/Internationalization.json
@@ -3,7 +3,7 @@
   "headerText": "Vuetify supports language internationalization of its components. When installing Vuetify you can specify available locales and the currently active locale with the `lang` option. See the Getting started section. ",
   "gettingStarted": "Getting started",
   "gettingStartedText": "To set the available locales or the current locale, supply the `lang` option when installing Vuetify. The provided `locales` property will be merged with the already existing locales. You can change the locale during runtime through the `$vuetify` object on the Vue instance.",
-  "availableLocalesText": "Currently Vuetify provides translations in the following languages: English (**en**), Catalan (**ca**), traditional Chinese (**zh-Hant**), simpified Chinese (**zh-Hans**), Dutch (**nl**), Farsi (**fa**), French (**fr**), German (**de**), Greek (**gr**), Italian (**it**), Polish (**pl**), Portuguese (**pt**), Russian (**ru**), Serbian cyrilic (**sr-Cyrl**) and Ukrainian (**uk**).",
+  "availableLocalesText": "Currently Vuetify provides translations in the following languages:",
   "createTranslation": "Create translation",
   "createTranslationText": "To create your own translation, use the code below or copy and rename the file `vuetify/src/locale/en.ts` to your project and make your changes.",
   "customComponents": "Custom components",

--- a/src/pages/framework/InternationalizationPage.vue
+++ b/src/pages/framework/InternationalizationPage.vue
@@ -16,6 +16,12 @@
       helpers-section-head(value="Framework.Internationalization.gettingStarted")
       helpers-section-text(value="Framework.Internationalization.gettingStartedText")
       helpers-section-text(value="Framework.Internationalization.availableLocalesText")
+      div.text-xs-justify.ml-3
+        p
+          span(v-for="({localeCode, localeName, localeNativeName}, index) in localeNames")
+            | {{ index ? ', ' : '' }}
+            strong {{ localeCode }}
+            |  - {{ localeName }} {{ localeNativeName ? ` (${localeNativeName})` : '' }}
       helpers-markup(lang="js")
         | import Vuetify from 'vuetify'
         |
@@ -50,7 +56,7 @@
       helpers-section-text(value="Framework.Internationalization.createTranslationText")
 
       helpers-markup(lang="js")
-        | export default {{ enLocale }}
+        | export default {{ locales.en }}
 
     section#custom-components
       helpers-section-head(value="Framework.Internationalization.customComponents")
@@ -120,11 +126,12 @@
 </template>
 
 <script>
-  import enLocale from 'vuetify/es5/locale/en'
+  import locales from 'vuetify/es5/locale/index'
+  import ISO6391 from 'iso-639-1'
 
   export default {
     data: vm => ({
-      enLocale,
+      locales,
       headers: [
         { value: 'name', size: 1 },
         { value: 'default', size: 7 },
@@ -147,6 +154,17 @@
           type: 'Function'
         }
       ]
-    })
+    }),
+    computed: {
+      localeNames () {
+        const array = Object.keys(locales).map(localeCode => ({
+          localeCode,
+          localeName: ISO6391.getName(localeCode.substr(0, 2)),
+          localeNativeName: localeCode === 'en' ? '' : ISO6391.getNativeName(localeCode.substr(0, 2))
+        }))
+        array.sort((a, b) => (a.localeCode < b.localeCode ? -1 : (a.localeCode > b.localeCode ? 1 : 0)))
+        return array
+      }
+    }
   }
 </script>

--- a/src/pages/framework/InternationalizationPage.vue
+++ b/src/pages/framework/InternationalizationPage.vue
@@ -126,7 +126,7 @@
 </template>
 
 <script>
-  import locales from 'vuetify/es5/locale/index'
+  import * as locales from 'vuetify/es5/locale'
   import ISO6391 from 'iso-639-1'
 
   export default {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4774,6 +4774,11 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
+iso-639-1@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/iso-639-1/-/iso-639-1-2.0.3.tgz#72dd3448ac5629c271628c5ac566369428d6ccd0"
+  integrity sha512-PZhOTDH05ZLJyCqxAH65EzGaLO801KCvoEahAFoiqlp2HmnGUm8sO19KwWPCiWd3odjmoYd9ytzk2WtVYgWyCg==
+
 isobject@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15625235/47489621-3f515900-d871-11e8-90ce-6e4d65ac2cac.png)

https://github.com/vuetifyjs/vuetify/pull/5425

Edit: just found https://github.com/mattcg/language-subtag-registry, will try to support also script (hans, cyrl etc)