### PR TITLE
Fixed checkbox validation for vuelidate example form

### DIFF
--- a/src/examples/forms/vuelidate.vue
+++ b/src/examples/forms/vuelidate.vue
@@ -51,7 +51,11 @@
       name: { required, maxLength: maxLength(10) },
       email: { required, email },
       select: { required },
-      checkbox: { required }
+      checkbox: {
+        checked (val) {
+          return val
+        }
+      }
     },
 
     data: () => ({
@@ -71,7 +75,7 @@
       checkboxErrors () {
         const errors = []
         if (!this.$v.checkbox.$dirty) return errors
-        !this.$v.checkbox.required && errors.push('You must agree to continue!')
+        !this.$v.checkbox.checked && errors.push('You must agree to continue!')
         return errors
       },
       selectErrors () {


### PR DESCRIPTION
In newer versions of vuelidate users will run into an issue where the checkbox validation from the example provided on https://vuetifyjs.com/en/components/forms will not work. This is due to a change to how vuelidate handles "required" on check-boxes.

The commit contains a simple fix for the issue until the staff over at Monterail add a dedicated checked validator as discussed in vuelidate issue #[305](https://github.com/monterail/vuelidate/issues/305)

### Demo
Current copy-pasted example (with newer versions of vuelidate):
![pre-fix](https://user-images.githubusercontent.com/39649820/47602095-f1a43000-d9d9-11e8-912f-50900255dff2.gif)

With simple fix:
![post-fix](https://user-images.githubusercontent.com/39649820/47602106-0e406800-d9da-11e8-9db4-672110b8a8cf.gif)
